### PR TITLE
Add organization setup flow

### DIFF
--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -1,0 +1,23 @@
+import { Logo } from "@/components/icons";
+import { OrganizationList } from "@clerk/nextjs";
+import Link from "next/link";
+
+export default async function OrganizationPage() {
+  return (
+    <main className="container min-h-screen max-w-sm flex items-center justify-center">
+      <div className="flex flex-col items-center justify-center gap-6">
+        <Link href="/">
+          <Logo className="size-10 mr-auto" />
+        </Link>
+        <h1 className="text-4xl leading-tight font-bold">
+          You are not part of an organization
+        </h1>
+        <OrganizationList
+          hidePersonal
+          afterCreateOrganizationUrl="/dashboard"
+          afterSelectOrganizationUrl="/dashboard"
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,17 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
 
 export default clerkMiddleware(async (auth, req) => {
+  const { orgId } = await auth();
+
   if (isPublicRoute(req)) {
     return;
+  }
+
+  if (!orgId && !req.url.includes("/organization")) {
+    return NextResponse.redirect(new URL("/organization", req.url));
   }
 
   await auth.protect();


### PR DESCRIPTION
## Summary
- Add organization page for users not part of an organization
- Update middleware to redirect users without organization to /organization page
- Integrate Clerk's OrganizationList component for creating/joining organizations

## Test plan
- [ ] Verify users without organization are redirected to /organization
- [ ] Test organization creation flow
- [ ] Confirm redirect to dashboard after organization selection