### PR TITLE
feat: add patient deletion warning dialog with cascade delete

### DIFF
--- a/src/app/(protected)/patients/actions.ts
+++ b/src/app/(protected)/patients/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
 import type { PatientWithMedicalData } from "@/lib/types/database";
 import type { Patient } from "@/lib/types/entities";
 import { transformPatientWithMedicalData } from "@/lib/transforms/database";
@@ -171,6 +172,9 @@ export async function createPatient(
       throw patientError;
     }
 
+    // Revalidate the patients route
+    revalidatePath("/patients");
+
     return (await getPatient(patient.id)) as Patient;
   } catch (error) {
     console.error("Error in createPatient:", error);
@@ -231,6 +235,9 @@ export async function updatePatient(
       throw error;
     }
 
+    // Revalidate the patients route
+    revalidatePath("/patients");
+
     return (await getPatient(id)) as Patient;
   } catch (error) {
     console.error("Error in updatePatient:", error);
@@ -266,6 +273,9 @@ export async function deletePatient(id: string): Promise<void> {
       console.error("Error deleting patient:", error);
       throw error;
     }
+
+    // Revalidate the patients route
+    revalidatePath("/patients");
   } catch (error) {
     console.error("Error in deletePatient:", error);
     throw error;

--- a/src/app/(protected)/patients/actions.ts
+++ b/src/app/(protected)/patients/actions.ts
@@ -252,7 +252,7 @@ export async function deletePatient(id: string): Promise<void> {
 
     const supabase = await createClient();
 
-    // Delete related medical records first (due to foreign key constraints)
+    // Delete all related records first (due to foreign key constraints)
     await Promise.all([
       supabase.from("diagnoses").delete().eq("patient_id", id),
       supabase.from("medications").delete().eq("patient_id", id),
@@ -260,6 +260,7 @@ export async function deletePatient(id: string): Promise<void> {
       supabase.from("lab_results").delete().eq("patient_id", id),
       supabase.from("vital_signs").delete().eq("patient_id", id),
       supabase.from("clinical_notes").delete().eq("patient_id", id),
+      supabase.from("appointments").delete().eq("patient_id", id),
     ]);
 
     // Delete patient record

--- a/src/app/(protected)/patients/page.tsx
+++ b/src/app/(protected)/patients/page.tsx
@@ -1,16 +1,27 @@
 import { PatientsDataTable } from "./patients-data-table";
 import { getPatients } from "./actions";
+import { Button } from "@/components/ui/button";
+import { PlusIcon } from "lucide-react";
+import { CreatePatientModal } from "@/components/modals/create-patient-modal";
 
 export default async function PatientsPage() {
   const patients = await getPatients();
 
   return (
     <main className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Patients</h1>
-        <p className="text-muted-foreground">
-          Manage and track all patients across your healthcare facility.
-        </p>
+      <div className="flex items-center flex-wrap justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Patients</h1>
+          <p className="text-muted-foreground">
+            Manage and track all patients across your healthcare facility.
+          </p>
+        </div>
+        <CreatePatientModal>
+          <Button>
+            <PlusIcon />
+            Add Patient
+          </Button>
+        </CreatePatientModal>
       </div>
       
       <PatientsDataTable data={patients} />

--- a/src/app/(protected)/patients/patients-data-table.tsx
+++ b/src/app/(protected)/patients/patients-data-table.tsx
@@ -58,6 +58,7 @@ import { deletePatient } from "./actions";
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { EditPatientModal } from "@/components/modals/edit-patient-modal";
+import { DeletePatientDialog } from "@/components/dialogs/delete-patient-dialog";
 
 const statusColors = {
   active: "bg-green-500/10 text-green-700 dark:text-green-400",
@@ -76,20 +77,20 @@ interface PatientActionsProps {
 
 function PatientActions({ patient }: PatientActionsProps) {
   const [isPending, startTransition] = useTransition();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const router = useRouter();
 
   const handleDeletePatient = () => {
-    if (confirm(`Are you sure you want to delete patient ${patient.name}? This action cannot be undone.`)) {
-      startTransition(async () => {
-        try {
-          await deletePatient(patient.id);
-          router.refresh();
-        } catch (error) {
-          console.error('Error deleting patient:', error);
-          alert('Failed to delete patient. Please try again.');
-        }
-      });
-    }
+    startTransition(async () => {
+      try {
+        await deletePatient(patient.id);
+        setShowDeleteDialog(false);
+        router.refresh();
+      } catch (error) {
+        console.error('Error deleting patient:', error);
+        alert('Failed to delete patient. Please try again.');
+      }
+    });
   };
 
   return (
@@ -143,14 +144,22 @@ function PatientActions({ patient }: PatientActionsProps) {
         <DropdownMenuSeparator />
         
         <DropdownMenuItem 
-          onClick={handleDeletePatient}
+          onClick={() => setShowDeleteDialog(true)}
           className="text-red-600 focus:text-red-600"
           disabled={isPending}
         >
           <FileText className="mr-2 h-4 w-4" />
-          {isPending ? 'Deleting...' : 'Delete Patient'}
+          Delete Patient
         </DropdownMenuItem>
       </DropdownMenuContent>
+      
+      <DeletePatientDialog
+        patient={patient}
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        onConfirm={handleDeletePatient}
+        isLoading={isPending}
+      />
     </DropdownMenu>
   );
 }

--- a/src/app/(protected)/patients/patients-data-table.tsx
+++ b/src/app/(protected)/patients/patients-data-table.tsx
@@ -57,6 +57,7 @@ import Link from "next/link";
 import { deletePatient } from "./actions";
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { EditPatientModal } from "@/components/modals/edit-patient-modal";
 
 const statusColors = {
   active: "bg-green-500/10 text-green-700 dark:text-green-400",
@@ -110,10 +111,12 @@ function PatientActions({ patient }: PatientActionsProps) {
           </Link>
         </DropdownMenuItem>
         
-        <DropdownMenuItem disabled>
-          <Edit className="mr-2 h-4 w-4" />
-          Edit Patient
-        </DropdownMenuItem>
+        <EditPatientModal patient={patient}>
+          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+            <Edit className="mr-2 h-4 w-4" />
+            Edit Patient
+          </DropdownMenuItem>
+        </EditPatientModal>
         
         <DropdownMenuItem disabled>
           <Calendar className="mr-2 h-4 w-4" />

--- a/src/components/dialogs/delete-patient-dialog.tsx
+++ b/src/components/dialogs/delete-patient-dialog.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { AlertTriangle } from "lucide-react";
+import { type Patient } from "@/lib/types/entities";
+
+interface DeletePatientDialogProps {
+  patient: Patient | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+export function DeletePatientDialog({
+  patient,
+  open,
+  onOpenChange,
+  onConfirm,
+  isLoading = false,
+}: DeletePatientDialogProps) {
+  if (!patient) return null;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-600" />
+            <AlertDialogTitle>Delete Patient</AlertDialogTitle>
+          </div>
+          <AlertDialogDescription className="space-y-2">
+            <p>
+              Are you sure you want to delete <strong>{patient.name}</strong>?
+            </p>
+            <p className="text-red-600 font-medium">
+              ⚠️ This will permanently delete:
+            </p>
+            <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground ml-4">
+              <li>All medical records (diagnoses, medications, procedures)</li>
+              <li>All lab results and vital signs</li>
+              <li>All clinical notes</li>
+              <li>All appointments for this patient</li>
+            </ul>
+            <p className="text-red-600 font-medium">
+              This action cannot be undone.
+            </p>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+          >
+            {isLoading ? "Deleting..." : "Delete Patient"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/dialogs/delete-patient-dialog.tsx
+++ b/src/components/dialogs/delete-patient-dialog.tsx
@@ -10,8 +10,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { AlertTriangle } from "lucide-react";
+import {
+  AlertCircleIcon,
+  AlertTriangle,
+  TriangleAlertIcon,
+} from "lucide-react";
 import { type Patient } from "@/lib/types/entities";
+import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 
 interface DeletePatientDialogProps {
   patient: Patient | null;
@@ -35,33 +40,35 @@ export function DeletePatientDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <div className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-red-600" />
+            <AlertTriangle className="h-5 w-5 text-destructive" />
             <AlertDialogTitle>Delete Patient</AlertDialogTitle>
           </div>
           <AlertDialogDescription className="space-y-2">
             <p>
               Are you sure you want to delete <strong>{patient.name}</strong>?
             </p>
-            <p className="text-red-600 font-medium">
-              ⚠️ This will permanently delete:
-            </p>
-            <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground ml-4">
-              <li>All medical records (diagnoses, medications, procedures)</li>
-              <li>All lab results and vital signs</li>
-              <li>All clinical notes</li>
-              <li>All appointments for this patient</li>
-            </ul>
-            <p className="text-red-600 font-medium">
-              This action cannot be undone.
-            </p>
+            <Alert variant="destructive">
+              <AlertCircleIcon />
+              <AlertTitle>This will permanently delete:</AlertTitle>
+              <AlertDescription>
+                <ul className="list-disc list-inside space-y-1 text-sm">
+                  <li>
+                    All medical records (diagnoses, medications, procedures)
+                  </li>
+                  <li>All lab results and vital signs</li>
+                  <li>All clinical notes</li>
+                  <li>All appointments for this patient</li>
+                </ul>
+              </AlertDescription>
+            </Alert>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
           <AlertDialogAction
+            color="destructive"
             onClick={onConfirm}
             disabled={isLoading}
-            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
           >
             {isLoading ? "Deleting..." : "Delete Patient"}
           </AlertDialogAction>

--- a/src/components/dialogs/delete-patient-dialog.tsx
+++ b/src/components/dialogs/delete-patient-dialog.tsx
@@ -10,11 +10,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import {
-  AlertCircleIcon,
-  AlertTriangle,
-  TriangleAlertIcon,
-} from "lucide-react";
+import { AlertCircleIcon, AlertTriangle } from "lucide-react";
 import { type Patient } from "@/lib/types/entities";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 

--- a/src/components/forms/edit-patient-form.tsx
+++ b/src/components/forms/edit-patient-form.tsx
@@ -1,0 +1,498 @@
+"use client";
+
+import { useTransition, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { User, Phone, Shield, Heart } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { updatePatient } from "@/app/(protected)/patients/actions";
+import { toast } from "sonner";
+import type { Patient } from "@/lib/types/entities";
+
+const patientFormSchema = z.object({
+  name: z.string().min(2, "Patient name must be at least 2 characters."),
+  dateOfBirth: z.string().min(1, "Date of birth is required."),
+  gender: z.enum(["male", "female", "other"]),
+  address: z.string().min(1, "Address is required."),
+  phone: z.string().min(1, "Phone number is required."),
+  email: z.string().email("Please enter a valid email address."),
+  emergencyContactName: z
+    .string()
+    .min(1, "Emergency contact name is required."),
+  emergencyContactPhone: z
+    .string()
+    .min(1, "Emergency contact phone is required."),
+  emergencyContactRelationship: z
+    .string()
+    .min(1, "Emergency contact relationship is required."),
+  insuranceProvider: z.string().min(1, "Insurance provider is required."),
+  insurancePolicyNumber: z
+    .string()
+    .min(1, "Insurance policy number is required."),
+  smokingStatus: z.enum(["never", "former", "current"]),
+  alcoholConsumption: z.enum(["none", "occasional", "moderate", "heavy"]),
+  allergies: z.string().optional(),
+  familyHistory: z.string().optional(),
+});
+
+type PatientFormValues = z.infer<typeof patientFormSchema>;
+
+interface EditPatientFormProps {
+  patient: Patient;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+export function EditPatientForm({
+  patient,
+  onSuccess,
+  onCancel,
+}: EditPatientFormProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<PatientFormValues>({
+    resolver: zodResolver(patientFormSchema),
+    defaultValues: {
+      name: "",
+      dateOfBirth: "",
+      gender: "male",
+      address: "",
+      phone: "",
+      email: "",
+      emergencyContactName: "",
+      emergencyContactPhone: "",
+      emergencyContactRelationship: "",
+      insuranceProvider: "",
+      insurancePolicyNumber: "",
+      smokingStatus: "never",
+      alcoholConsumption: "none",
+      allergies: "",
+      familyHistory: "",
+    },
+  });
+
+  // Set form values when patient data is available
+  useEffect(() => {
+    if (patient) {
+      form.reset({
+        name: patient.name,
+        dateOfBirth: patient.dateOfBirth || "",
+        gender: (patient.gender as "male" | "female" | "other") || "male",
+        address: patient.contactInfo.address,
+        phone: patient.contactInfo.phone,
+        email: patient.contactInfo.email,
+        emergencyContactName: patient.emergencyContact.name,
+        emergencyContactPhone: patient.emergencyContact.phone,
+        emergencyContactRelationship: patient.emergencyContact.relationship,
+        insuranceProvider: patient.insurance.provider,
+        insurancePolicyNumber: patient.insurance.policyNumber,
+        smokingStatus: (patient.socialHistory.smokingStatus as "never" | "former" | "current") || "never",
+        alcoholConsumption: (patient.socialHistory.alcoholConsumption as "none" | "occasional" | "moderate" | "heavy") || "none",
+        allergies: patient.allergies ? patient.allergies.join(", ") : "",
+        familyHistory: patient.familyHistory ? patient.familyHistory.join(", ") : "",
+      });
+    }
+  }, [patient, form]);
+
+  const onSubmit = (values: PatientFormValues) => {
+    startTransition(async () => {
+      try {
+        const patientData = {
+          name: values.name,
+          dateOfBirth: values.dateOfBirth,
+          age:
+            new Date().getFullYear() -
+            new Date(values.dateOfBirth).getFullYear(),
+          gender: values.gender,
+          contactInfo: {
+            address: values.address,
+            phone: values.phone,
+            email: values.email,
+          },
+          emergencyContact: {
+            name: values.emergencyContactName,
+            phone: values.emergencyContactPhone,
+            relationship: values.emergencyContactRelationship,
+          },
+          insurance: {
+            provider: values.insuranceProvider,
+            policyNumber: values.insurancePolicyNumber,
+          },
+          socialHistory: {
+            smokingStatus: values.smokingStatus,
+            alcoholConsumption: values.alcoholConsumption,
+          },
+          allergies: values.allergies
+            ? values.allergies.split(",").map((a) => a.trim())
+            : [],
+          familyHistory: values.familyHistory
+            ? values.familyHistory.split(",").map((h) => h.trim())
+            : [],
+        };
+
+        await updatePatient(patient.id, patientData);
+
+        toast.success("Patient updated successfully!", {
+          description: `${values.name}'s information has been updated.`,
+        });
+
+        onSuccess?.();
+      } catch (error) {
+        console.error("Failed to update patient:", error);
+        toast.error("Failed to update patient", {
+          description:
+            "Please try again or contact support if the problem persists.",
+        });
+      }
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <Tabs defaultValue="basic" className="w-full">
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="basic" className="flex items-center gap-2">
+              <User className="h-4 w-4" />
+              Basic Info
+            </TabsTrigger>
+            <TabsTrigger value="contact" className="flex items-center gap-2">
+              <Phone className="h-4 w-4" />
+              Contact
+            </TabsTrigger>
+            <TabsTrigger value="emergency" className="flex items-center gap-2">
+              <Shield className="h-4 w-4" />
+              Emergency
+            </TabsTrigger>
+            <TabsTrigger value="medical" className="flex items-center gap-2">
+              <Heart className="h-4 w-4" />
+              Medical
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="basic" className="space-y-4 mt-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Full Name *</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Enter patient's full name"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="dateOfBirth"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date of Birth *</FormLabel>
+                    <FormControl>
+                      <Input type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="gender"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Gender *</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select gender" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="male">Male</SelectItem>
+                        <SelectItem value="female">Female</SelectItem>
+                        <SelectItem value="other">Other</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="contact" className="space-y-4 mt-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Phone Number *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="(555) 123-4567" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email Address *</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="patient@email.com"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Address *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="123 Main St, City, State, ZIP"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </TabsContent>
+
+          <TabsContent value="emergency" className="space-y-4 mt-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="emergencyContactName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Emergency Contact Name *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="John Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="emergencyContactPhone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Emergency Contact Phone *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="(555) 123-4567" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="emergencyContactRelationship"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Relationship *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Spouse, Parent, etc." {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </TabsContent>
+
+          <TabsContent value="medical" className="space-y-4 mt-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="insuranceProvider"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Insurance Provider *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Blue Cross Blue Shield" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="insurancePolicyNumber"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Policy Number *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="BCBS123456789" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="smokingStatus"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Smoking Status *</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select smoking status" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="never">Never</SelectItem>
+                        <SelectItem value="former">Former</SelectItem>
+                        <SelectItem value="current">Current</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="alcoholConsumption"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Alcohol Consumption *</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select alcohol consumption" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="none">None</SelectItem>
+                        <SelectItem value="occasional">Occasional</SelectItem>
+                        <SelectItem value="moderate">Moderate</SelectItem>
+                        <SelectItem value="heavy">Heavy</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="allergies"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Allergies</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="List allergies separated by commas"
+                        className="resize-none"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="familyHistory"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Family History</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="List family medical history separated by commas"
+                        className="resize-none"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {/* Form Actions */}
+        <div className="flex items-center gap-4 pt-4">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                Updating...
+              </>
+            ) : (
+              "Update Patient"
+            )}
+          </Button>
+
+          {onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/modals/create-patient-modal.tsx
+++ b/src/components/modals/create-patient-modal.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { CreatePatientForm } from "@/components/forms/create-patient-form";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { PropsWithChildren } from "react";
+
+export const CreatePatientModal = ({ children }: PropsWithChildren) => {
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(false);
+
+  const handleSuccess = () => {
+    setOpen(false);
+  };
+
+  const handleCancel = () => {
+    setOpen(false);
+  };
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>{children}</DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Create Patient</DrawerTitle>
+          <DrawerDescription>
+            Add a new patient to your healthcare facility.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="pb-12 container overflow-y-auto">
+          <CreatePatientForm 
+            onSuccess={handleSuccess}
+            onCancel={handleCancel}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Patient</DialogTitle>
+          <DialogDescription>
+            Add a new patient to your healthcare facility.
+          </DialogDescription>
+        </DialogHeader>
+        <CreatePatientForm 
+          onSuccess={handleSuccess}
+          onCancel={handleCancel}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/modals/edit-patient-modal.tsx
+++ b/src/components/modals/edit-patient-modal.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { EditPatientForm } from "@/components/forms/edit-patient-form";
+import { useIsMobile } from "@/hooks/use-mobile";
+import type { Patient } from "@/lib/types/entities";
+import { PropsWithChildren } from "react";
+
+interface EditPatientModalProps extends PropsWithChildren {
+  patient: Patient;
+}
+
+export const EditPatientModal = ({ patient, children }: EditPatientModalProps) => {
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(false);
+
+  const handleSuccess = () => {
+    setOpen(false);
+  };
+
+  const handleCancel = () => {
+    setOpen(false);
+  };
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>{children}</DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Edit Patient</DrawerTitle>
+          <DrawerDescription>
+            Update patient information and medical details.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="pb-12 container overflow-y-auto">
+          <EditPatientForm 
+            patient={patient}
+            onSuccess={handleSuccess}
+            onCancel={handleCancel}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit Patient</DialogTitle>
+          <DialogDescription>
+            Update patient information and medical details.
+          </DialogDescription>
+        </DialogHeader>
+        <EditPatientForm 
+          patient={patient}
+          onSuccess={handleSuccess}
+          onCancel={handleCancel}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## Summary
- Implement comprehensive patient deletion warning dialog that explicitly warns users about all data that will be deleted
- Update patient deletion action to cascade delete appointments along with medical records
- Replace simple browser confirm dialog with proper shadcn/ui AlertDialog component

## Changes Made
- **New Component**: `DeletePatientDialog` - A detailed warning dialog that lists all data types that will be deleted
- **Enhanced Action**: Updated `deletePatient` function to include appointments in cascade deletion
- **Improved UX**: Replaced browser confirm with proper dialog component with loading states

## Data Deletion Warning
The dialog now explicitly warns users that deleting a patient will permanently remove:
- All medical records (diagnoses, medications, procedures)
- All lab results and vital signs
- All clinical notes
- **All appointments for this patient**

## Test Plan
- [x] Build passes without errors
- [x] Linting passes
- [x] Dialog shows proper warning message
- [x] Cascade deletion includes appointments
- [x] Loading states work correctly
- [x] Manual testing of patient deletion flow
- [x] Verify appointments are deleted when patient is deleted